### PR TITLE
Bugfix: Added missing table drop statement in create_table test

### DIFF
--- a/spec/dog_spec.rb
+++ b/spec/dog_spec.rb
@@ -39,6 +39,7 @@ describe "Dog" do
 
   describe "::create_table" do
     it 'creates the dogs table in the database' do
+      DB[:conn].execute('DROP TABLE IF EXISTS dogs')
       Dog.create_table
       table_check_sql = "SELECT tbl_name FROM sqlite_master WHERE type='table' AND tbl_name='dogs';"
       expect(DB[:conn].execute(table_check_sql)[0]).to eq(['dogs'])


### PR DESCRIPTION
Without this statement, the test passes as long as Dog.create_table is defined, even if it does nothing.